### PR TITLE
WEB-5354: Fixing e.scrollTop error and it's variants

### DIFF
--- a/src/vue-pull-to.vue
+++ b/src/vue-pull-to.vue
@@ -204,7 +204,10 @@
               bs.setProperty('transform', `translate(0, ${b}px)`);
               const fs = f.style;
               fs.setProperty('height', `${-b}px`);
-              this.$refs['scroll-container'].scrollTop -= b;
+              const el = this.$refs['scroll-container'];
+              if(el) {
+                this.$refs['scroll-container'].scrollTop -= b;
+              }
 
               const tdur = '200ms';
               const tdelay = `${c.loadedStayTime}ms`;
@@ -260,7 +263,7 @@
         this.beforeDiff = this.diff;
         const sc = this.$refs['scroll-container'];
         this.shouldPullDown =
-          this.isTopBounce && sc.scrollTop === 0;
+          this.isTopBounce && (sc ? sc.scrollTop === 0 : false);
         this.shouldPullUp =
           this.isBottomBounce && this.checkBottomReached();
         this.shouldPassThroughEvent = false;
@@ -350,6 +353,9 @@
 
       updateTouchSensitivity(flag) {
         const el = this.$refs['scroll-container'];
+        if(!el) {
+          return;
+        }
         if (flag) {
           el.addEventListener('touchstart', this.handleTouchStart, PASSIVE_OPTS);
           el.addEventListener('touchmove', this.handleTouchMove);
@@ -363,6 +369,9 @@
 
       updateScrollSensitivity(flag) {
         const el = this.$refs['scroll-container'];
+        if(!el) {
+          return;
+        }
         if (flag) {
           el.addEventListener('scroll', this.handleScroll, PASSIVE_OPTS);
         } else {

--- a/src/vue-pull-to.vue
+++ b/src/vue-pull-to.vue
@@ -252,7 +252,7 @@
 
       checkBottomReached() {
         const el = this.$refs['scroll-container'];
-        return el.scrollTop + el.offsetHeight + 1 >= el.scrollHeight;
+        return el ? el.scrollTop + el.offsetHeight + 1 >= el.scrollHeight : false;
       },
 
       handleTouchStart(event) {


### PR DESCRIPTION
The core problem: The events are being triggered before the component is ready to go and it's $refs are ready.  It seems to be specific to using an actual device, as I haven't seen it in the simulator or web views.

This change will protect against several possible instances of this, but this is _very_ difficult to reproduce normally.  To confirm this was working I ended up adding a few console.log entries along with the guard and running with that; I've had the best luck navigating between a lot of Feedback entries, but it is currently very random.

Once this is merged, a sequel PR will be created to update the actual project.